### PR TITLE
Collect feature maps during forward pass

### DIFF
--- a/src/nn.ts
+++ b/src/nn.ts
@@ -250,8 +250,13 @@ export function buildNetwork(
  *     nodes in the network.
  * @return The final output of the network.
  */
+export interface ForwardResult {
+  prediction: number;
+  featureMaps: {[layer: number]: number[]};
+}
+
 export function forwardProp(network: Node[][], inputs: number[]):
-    {prediction: number, featureMaps: {[layer: number]: number[]}} {
+    ForwardResult {
   let inputLayer = network[0];
   if (inputs.length !== inputLayer.length) {
     throw new Error("The number of inputs must match the number of nodes in" +
@@ -265,12 +270,17 @@ export function forwardProp(network: Node[][], inputs: number[]):
   let featureMaps: {[layer: number]: number[]} = {};
   for (let layerIdx = 1; layerIdx < network.length; layerIdx++) {
     let currentLayer = network[layerIdx];
-    featureMaps[layerIdx] = [];
+    // Collect pre-activation values for hidden layers only.
+    if (layerIdx < network.length - 1) {
+      featureMaps[layerIdx - 1] = [];
+    }
     // Update all the nodes in this layer.
     for (let i = 0; i < currentLayer.length; i++) {
       let node = currentLayer[i];
       node.updateOutput();
-      featureMaps[layerIdx].push(node.totalInput);
+      if (layerIdx < network.length - 1) {
+        featureMaps[layerIdx - 1].push(node.totalInput);
+      }
     }
   }
   return {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -911,8 +911,8 @@ function oneStep(): void {
   iter++;
   trainData.forEach((point, i) => {
     let input = constructInput(point.x, point.y);
-    let result = nn.forwardProp(network, input);
-    latestFeatureMaps = result.featureMaps;
+    let {featureMaps} = nn.forwardProp(network, input);
+    latestFeatureMaps = featureMaps;
     nn.backProp(network, point.label, nn.Errors.SQUARE);
     if ((i + 1) % state.batchSize === 0) {
       nn.updateWeights(network, state.learningRate, state.regularizationRate);


### PR DESCRIPTION
## Summary
- Capture pre-activation values for each layer during forward propagation
- Expose per-layer feature maps and final prediction from `forwardProp`
- Track latest feature maps in the training loop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build-js`


------
https://chatgpt.com/codex/tasks/task_e_689b91da5b508331a6209d152c130f5c